### PR TITLE
chore: update for linkerd v2.18

### DIFF
--- a/east/mc-values.yml
+++ b/east/mc-values.yml
@@ -1,0 +1,6 @@
+controllers:
+- link:
+    ref:
+      name: k3d-west
+  logLevel: debug
+  enableHeadlessServices: true

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ set -x
 
 ORG_DOMAIN="${ORG_DOMAIN:-cluster.local}"
 LINKERD="${LINKERD:-linkerd}"
+GATEWAY_API_VERSION="v1.1.1"
 
 case $(uname) in
 	Darwin)
@@ -48,6 +49,9 @@ for cluster in east west ; do
         --profile=intermediate-ca \
         --not-after 8760h --no-password --insecure
 
+    # Install GatewayAPI CRDs
+	  kubectl --context="k3d-$cluster" apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/experimental-install.yaml"
+
     #Install CRDs into cluster
     $LINKERD --context="k3d-$cluster" install --crds |  kubectl --context="k3d-$cluster" apply -f -
 
@@ -69,6 +73,6 @@ for cluster in east west ; do
     sleep 2
 
     # Setup the multicluster components on the server
-    $LINKERD --context="k3d-$cluster" multicluster install |
+    $LINKERD --context="k3d-$cluster" multicluster install -f "$cluster/mc-values.yml" |
         kubectl --context="k3d-$cluster" apply -f -
 done

--- a/link.sh
+++ b/link.sh
@@ -18,16 +18,15 @@ fetch_credentials() {
     
     # shellcheck disable=SC2001  
     echo "$($LINKERD --context="k3d-$cluster" \
-            multicluster link --set "enableHeadlessServices=true" \
+            multicluster link-gen \
             --cluster-name="k3d-$cluster" \
-            --log-level="debug" \
             --api-server-address="https://${lb_ip}:6443")" 
 }
 
 # East & West get access to each other.
-fetch_credentials east | kubectl --context=k3d-west apply -n linkerd-multicluster -f -
+fetch_credentials east | kubectl --context=k3d-west apply -f -
 
-fetch_credentials west | kubectl --context=k3d-east apply -n linkerd-multicluster -f -
+fetch_credentials west | kubectl --context=k3d-east apply -f -
 
 sleep 10
 for c in east west ; do

--- a/west/mc-values.yml
+++ b/west/mc-values.yml
@@ -1,0 +1,6 @@
+controllers:
+- link:
+    ref:
+      name: k3d-east
+  logLevel: debug
+  enableHeadlessServices: true


### PR DESCRIPTION
- Install GatewayAPI CRDs before installing linkerd
- Added multicluster config (east/mv-values.yml and west/mc-values.yml) to be fed into `linkerd mc install`
- Use `linkerd mc link-gen` instead of `linkerd mc link`
- Other various fixes

Tested against linkerd/website#1945